### PR TITLE
Restrict lookup of CONSTANT symbols to CONSTANT, VARIABLE, and PARAMETER

### DIFF
--- a/src/ffapl/lib/FFaplSymbol.java
+++ b/src/ffapl/lib/FFaplSymbol.java
@@ -236,7 +236,11 @@ public class FFaplSymbol implements ISymbol {
 				break;
 				
 			case ISymbol.CONSTANT:
-				    result = symbol.getID().equals(this.getID());
+				    if(symbol.getKind() == ISymbol.VARIABLE ||
+				    		symbol.getKind() == ISymbol.PARAMETER ||
+				    		symbol.getKind() == ISymbol.CONSTANT){
+				    	result = symbol.getID().equals(this.getID());
+				    }
 				break;
 			case ISymbol.PROGRAM:
 				    result = symbol.getID().equals(this.getID());


### PR DESCRIPTION
fixes issues with incorrect symbol lookup when declaring constants that shadow builtin functions.

Example program that triggers this issue:
```
program calculate{
    const p: Prime := 3;
    const ply: Polynomial := [1 + x^2];
    const gf: GF(p, ply) := [1 + x];

    n: Integer; n := 1;
    println(n);
}
```